### PR TITLE
Add coverage report by Codecov

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -34,6 +34,11 @@ jobs:
       - name: Teardown test environment
         run: make test-env-up
 
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
   golangci:
     name: lint
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Example of testing Go code with Postgres
 
+[![Go workflow status badge](https://github.com/xorcare/testing-go-code-with-postgres/actions/workflows/go.yml/badge.svg?branch=main)](https://github.com/xorcare/testing-go-code-with-postgres/actions/workflows/go.yml)
+[![codecov](https://codecov.io/github/xorcare/testing-go-code-with-postgres/branch/main/graph/badge.svg?token=AmPmVHf2ej)](https://codecov.io/github/xorcare/testing-go-code-with-postgres/tree/main)
+[![Go Report Card](https://goreportcard.com/badge/github.com/xorcare/testing-go-code-with-postgres)](https://goreportcard.com/report/github.com/xorcare/testing-go-code-with-postgres)
+
 The example suggests a solution to the problem of cleaning the database after
 running tests and the problem of running tests in parallel. It also shows how
 to organize integration testing of Go code with Postgres.


### PR DESCRIPTION
This is needed to display coverage, and as an example of setting up coverage counts.

Also, added badges to make the repositories look prettier.