### PR TITLE
Add GitLab CI and mirroring to GitLab

### DIFF
--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -1,0 +1,25 @@
+name: GitLab
+
+on: [ push ]
+
+jobs:
+  mirror:
+    name: Mirroring to GitLab
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Mirror repository to Gitlab
+        run: |
+          set -e -x
+          git remote add gitlab "${{ vars.GITLAB_REPO }}"
+          git config --global url."https://${{ vars.GITLAB_USERNAME }}:${{ secrets.GITLAB_PUSH_TOKEN }}@gitlab.com".insteadOf https://gitlab.com
+          git push --force gitlab "$GITHUB_REF_NAME"
+      - name: Run GitLab CI
+        run: >
+          curl -i --fail
+          --request POST
+          --form token=${{ secrets.GITLAB_CI_TOKEN }}
+          --form ref="${{ github.ref_name }}"
+          https://gitlab.com/api/v4/projects/${{ vars.GITLAB_PROJECT_ID }}/trigger/pipeline

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,48 @@
+image: golang:1.20
+
+stages:
+  - test
+
+# Check that all packages are compiling.
+build:
+  stage: test
+  script:
+    - make build
+  only:
+    - branches
+
+# Check that all integration tests are labeled.
+test-short:
+  stage: test
+  script:
+    - make test-short
+  only:
+    - branches
+
+# Runs all test.
+test:
+  services:
+    - docker:dind
+  stage: test
+  variables:
+    DOCKER_HOST: tcp://docker:2375
+    TESTING_DB_URL: postgresql://postgres:postgres@docker:32260/postgres?sslmode=disable
+  before_script:
+    - curl -L "https://github.com/docker/compose/releases/download/v2.19.1/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+    - chmod +x /usr/local/bin/docker-compose
+    - docker-compose --version
+    - make test-env-up
+  script:
+    - make test
+    - go get github.com/boumenot/gocover-cobertura
+    - go run github.com/boumenot/gocover-cobertura < coverage.out > coverage.xml
+  after_script:
+    - make test-env-down
+  artifacts:
+    reports:
+      coverage_report:
+        coverage_format: cobertura
+        path: coverage.xml
+  coverage: '/^total:\s+\(statements\)\s+(\d+(?:\.\d+)?%)/'
+  only:
+    - branches

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Go workflow status badge](https://github.com/xorcare/testing-go-code-with-postgres/actions/workflows/go.yml/badge.svg?branch=main)](https://github.com/xorcare/testing-go-code-with-postgres/actions/workflows/go.yml)
 [![codecov](https://codecov.io/github/xorcare/testing-go-code-with-postgres/branch/main/graph/badge.svg?token=AmPmVHf2ej)](https://codecov.io/github/xorcare/testing-go-code-with-postgres/tree/main)
+[![Gitlab CI Pipeline](https://gitlab.com/xorcare/testing-go-code-with-postgres/badges/main/pipeline.svg)](https://gitlab.com/xorcare/testing-go-code-with-postgres/tree/main)
+[![Gitlab CI Coverage](https://gitlab.com/xorcare/testing-go-code-with-postgres/badges/main/coverage.svg)](https://gitlab.com/xorcare/testing-go-code-with-postgres/tree/main)
 [![Go Report Card](https://goreportcard.com/badge/github.com/xorcare/testing-go-code-with-postgres)](https://goreportcard.com/report/github.com/xorcare/testing-go-code-with-postgres)
 
 The example suggests a solution to the problem of cleaning the database after


### PR DESCRIPTION
Added an example .gitlab-ci.yml, to make a sample more informative.

Also added mirroring to gitlab to simplify repository development and gitlab ci validation.