### PR TITLE
Fix placeholder for the database template name

### DIFF
--- a/docker-multiple-databases.sh
+++ b/docker-multiple-databases.sh
@@ -7,7 +7,7 @@ function create_user_and_database() {
   local database=$1
   echo "  Creating user and database '$database'"
   psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOSQL
-      CREATE DATABASE $database OWNER $POSTGRES_USER;
+      CREATE DATABASE "$database" OWNER $POSTGRES_USER;
 EOSQL
 }
 

--- a/testingpg/testingpg.go
+++ b/testingpg/testingpg.go
@@ -75,7 +75,7 @@ func (p *Postgres) cloneFromReference() *Postgres {
 	newDatabaseName := uuid.New().String()
 
 	sql := fmt.Sprintf(
-		`CREATE DATABASE %q WITH TEMPLATE %s;`,
+		`CREATE DATABASE %q WITH TEMPLATE %q;`,
 		newDatabaseName,
 		p.ref,
 	)


### PR DESCRIPTION
When a template database name contains invalid characters such as `-`, the request to create a new database stops working.

To reduce this behavior, quotation marks have been added.