### PR TITLE
Make human-readable database name

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,22 @@ to organize integration testing of Go code with Postgres.
   of [GitHub Actions](https://github.com/xorcare/testing-go-code-with-postgres/blob/main/.github/workflows/go.yml)
   and [Gitlab CI](https://github.com/xorcare/testing-go-code-with-postgres/blob/main/.gitlab-ci.yml).
 
+Generating human-readable database names from `t.Name()` to simplifying problem investigation.
+The last 8 characters are a short unique identifier needed to prevent name collision, its necessary
+because the maximum length of the name is 63 bytes, and the name must be unique.
+
+```txt
+TestNewPostgres-Changes-are-not-visible-in-different-inWirPQD7J
+TestNewPostgres-Changes-are-not-visible-in-different-ineYp0ljjI
+TestNewPostgres-Successfully-connect-by-URL-and-get-verzGq4pGza
+TestNewPostgres-Successfully-obtained-a-version-using-a20YgZaMf
+TestNewPostgres-URL-is-different-at-different-instancesIMDkJgoP
+TestNewPostgres-URL-is-different-at-different-instancesjtSsjPR5
+TestUserRepository-CreateUser-Cannot-create-a-user-withmgmHFdZe
+TestUserRepository-CreateUser-Successfully-created-a-UspTBGNltW
+TestUserRepository-ReadUser-Get-an-error-if-the-user-doRqS1GvYh
+```
+
 ## How to use
 
 Run `make test-env-up test` and then everything will happen by itself.


### PR DESCRIPTION
Sometimes tests terminate fatally and databases are not deleted and you want to understand which test left garbage behind. It is also in the future it will be possible to add the ability not to delete databases for tests that ended with an error, and it will be necessary to understand from which test the database.

Therefore, the generation of the database name from the name of the test with the addition of a unique identifier so that the names do not overlap.

    Reports the maximum identifier length. It is determined as one less
    than the value of NAMEDATALEN when building the server. The default
    value of NAMEDATALEN is 64; therefore the default
    max_identifier_length is 63 bytes, which can be less than 63
    characters when using multibyte encodings.

See https://www.postgresql.org/docs/15/runtime-config-preset.html

    PostgreSQL allows you to create any number of databases at a given
    site. Database names must have an alphabetic first character and
    are limited to 63 bytes in length. A convenient choice is to create
    a database with the same name as your current user name. Many tools
    assume that database name as the default, so it can save you some
    typing. To create that database, simply type:

See https://www.postgresql.org/docs/15/tutorial-createdb.html