### PR TITLE
Make return the exit code of a 'migrate' service container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ test-short: ## Run only unit tests, tests without I/O dependencies.
 
 .PHONY: test-env-up
 test-env-up: ## Run test environment.
-	@docker-compose up migrate
+	@docker-compose up --exit-code-from migrate migrate
 
 .PHONY: test-env-down
 test-env-down: ## Down and cleanup test environment.


### PR DESCRIPTION
This will make it easier to debug problems, because if an error occurs, it returns from docker-compose and interrupts the chain of commands, for example:

make test-env-down test-env-up test