### PR TITLE
Migrate to Compose V2

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,9 +28,10 @@ test:
     DOCKER_HOST: tcp://docker:2375
     TESTING_DB_URL: postgresql://postgres:postgres@docker:32260/postgres?sslmode=disable
   before_script:
-    - curl -L "https://github.com/docker/compose/releases/download/v2.19.1/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-    - chmod +x /usr/local/bin/docker-compose
-    - docker-compose --version
+    - curl -fsSL https://get.docker.com -o install-docker.sh
+    - sh install-docker.sh
+    - docker version
+    - docker compose version
     - make test-env-up
   script:
     - make test

--- a/Makefile
+++ b/Makefile
@@ -20,11 +20,11 @@ test-short: ## Run only unit tests, tests without I/O dependencies.
 
 .PHONY: test-env-up
 test-env-up: ## Run test environment.
-	@docker-compose up --exit-code-from migrate migrate
+	@docker compose up --exit-code-from migrate migrate
 
 .PHONY: test-env-down
 test-env-down: ## Down and cleanup test environment.
-	@docker-compose down -v
+	@docker compose down -v
 
 .PHONY: lint
 lint: tools ## Check the project with lint.


### PR DESCRIPTION
From July 2023 Compose V1 stopped receiving updates. It’s also no longer available in new releases of Docker Desktop.

Compose V2, which was first released in 2020, is included with all currently supported versions of Docker Desktop. It offers an improved CLI experience, improved build performance with BuildKit, and continued new-feature development.

See https://docs.docker.com/compose/migrate
See https://docs.docker.com/compose/reference