### PR TITLE
Remove trigger of Gitlab sync for merge requests

### DIFF
--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -2,8 +2,6 @@ name: GitLab
 
 on:
   push:
-  pull_request:
-    branches: ["main"]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Duplicate triggers cause problems, so only the push trigger is left.